### PR TITLE
サインイン/サインアップ画面の作成

### DIFF
--- a/src/components/page/Sign/Sign.tsx
+++ b/src/components/page/Sign/Sign.tsx
@@ -1,0 +1,27 @@
+import type { VFC } from "react";
+
+import { Logo } from "~/components/ui/Assets/Logo";
+import { Button } from "~/components/ui/Button";
+import { useAuth } from "~/hooks";
+
+type SignProps = {
+  page: "signin" | "signup";
+};
+
+export const Sign: VFC<SignProps> = (props) => {
+  const { handleLogin } = useAuth();
+
+  return (
+    <div className="flex flex-col justify-center items-center h-screen bg-gray-200">
+      <Logo width={192} height={36} />
+      <div className="mt-20">
+        <Button
+          className="py-4 w-72 font-bold bg-white hover:bg-gray-100 focus:bg-gray-100 rounded-full focus:outline-none focus-visible:ring-2 transition duration-200 ease-in-out sm:w-80"
+          onClick={handleLogin}
+        >
+          {props.page === "signin" ? "ログイン" : "アカウント作成"}
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/page/Sign/index.ts
+++ b/src/components/page/Sign/index.ts
@@ -1,0 +1,1 @@
+export { Sign } from "./Sign";

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -1,0 +1,18 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { forwardRef } from "react";
+
+type ButtonProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+type ButtonType = ButtonHTMLAttributes<HTMLButtonElement> & ButtonProps;
+
+export const Button = forwardRef<HTMLButtonElement, ButtonType>((props, ref) => {
+  const { children, className, ...rest } = props;
+  return (
+    <button type="button" ref={ref} {...rest} className={className}>
+      {children}
+    </button>
+  );
+});

--- a/src/components/ui/Button/index.ts
+++ b/src/components/ui/Button/index.ts
@@ -1,0 +1,1 @@
+export { Button } from "./Button";

--- a/src/pages/auth/signin.page.tsx
+++ b/src/pages/auth/signin.page.tsx
@@ -1,0 +1,10 @@
+import type { NextPage } from "next";
+
+import { Sign } from "~/components/page/Sign";
+
+const Signin: NextPage = () => {
+  return <Sign page="signin" />;
+};
+
+// eslint-disable-next-line import/no-default-export
+export default Signin;

--- a/src/pages/auth/signup.page.tsx
+++ b/src/pages/auth/signup.page.tsx
@@ -1,0 +1,10 @@
+import type { NextPage } from "next";
+
+import { Sign } from "~/components/page/Sign";
+
+const Signup: NextPage = () => {
+  return <Sign page="signup" />;
+};
+
+// eslint-disable-next-line import/no-default-export
+export default Signup;


### PR DESCRIPTION
close #35 

## 作成・変更内容
- サインイン・サインアップ画面の作成

## 参考画像
<img width="930" alt="CleanShot 2022-03-07 at 01 43 24@2x" src="https://user-images.githubusercontent.com/70119474/156933013-1fb24863-82a3-4b2d-b99d-981445e18b1e.png">
<img width="931" alt="CleanShot 2022-03-07 at 01 43 46@2x" src="https://user-images.githubusercontent.com/70119474/156933020-f3b47033-68db-4472-8175-1a75ea9d8700.png">


## 備考
- Qin MemoではGoogleログインとAppleログインで分かれているのですが、Auth0のログイン画面が以下のようになっていて、GoogleログインとAppleログインの出し分けがパッと見難しそう(?)だったので一旦シンプルなボタンを置いておくに留めました🙇‍♀️（Qin Memoのように出来る方法あれば模索したいですね🐶）

<img width="617" alt="CleanShot 2022-03-07 at 01 51 31@2x" src="https://user-images.githubusercontent.com/70119474/156933176-024dcde5-63e2-4e1a-bc57-cac745f518eb.png">

