### PR TITLE
feat:プロフィールメニューコンポーネントの作成（UI）

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@apollo/client": "^3.5.8",
     "@auth0/auth0-react": "^1.9.0",
+    "@headlessui/react": "^1.5.0",
     "@heroicons/react": "^1.0.6",
     "clsx": "^1.1.1",
     "daisyui": "^1.25.4",

--- a/src/components/model/user/Avatar.tsx
+++ b/src/components/model/user/Avatar.tsx
@@ -12,7 +12,11 @@ type AvatarProps = {
 export const Avatar: VFC<AvatarProps> = (props) => {
   return (
     <div className={props.className}>
-      {props.src ? <Image src={props.src} alt={props.alt} width={36} height={36} /> : <UserCircleIcon />}
+      {props.src ? (
+        <Image src={props.src} alt={props.alt} width={36} height={36} />
+      ) : (
+        <UserCircleIcon className="w-9 h-9 text-base-300" />
+      )}
     </div>
   );
 };

--- a/src/components/ui/Layout/Header.tsx
+++ b/src/components/ui/Layout/Header.tsx
@@ -1,7 +1,6 @@
 import clsx from "clsx";
 import type { VFC } from "react";
 
-import { Avatar } from "~/components/model/user/Avatar";
 import { ChevronLeftIcon } from "~/components/ui/Assets/HeroIcon";
 import { CloseIcon } from "~/components/ui/Assets/HeroIcon";
 import { Logo } from "~/components/ui/Assets/Logo";
@@ -36,9 +35,7 @@ export const Header: VFC<HeaderProps> = (props) => {
 
         {!props.centerTitle ? (
           <div className="absolute right-0">
-            <AvatarMenu>
-              <Avatar />
-            </AvatarMenu>
+            <AvatarMenu />
           </div>
         ) : null}
       </div>

--- a/src/components/ui/Layout/Header.tsx
+++ b/src/components/ui/Layout/Header.tsx
@@ -6,6 +6,7 @@ import { ChevronLeftIcon } from "~/components/ui/Assets/HeroIcon";
 import { CloseIcon } from "~/components/ui/Assets/HeroIcon";
 import { Logo } from "~/components/ui/Assets/Logo";
 import { IconButton } from "~/components/ui/Button/IconButton";
+import { AvatarMenu } from "~/components/ui/Menu/AvatarMenu";
 import { useIsPage } from "~/hooks/useIsPage";
 
 export type HeaderProps = {
@@ -33,7 +34,13 @@ export const Header: VFC<HeaderProps> = (props) => {
 
         {props.centerTitle ? <h1 className="text-lg font-bold text-base-content">{props.centerTitle}</h1> : <Logo />}
 
-        {!props.centerTitle ? <Avatar className="absolute right-0" /> : null}
+        {!props.centerTitle ? (
+          <div className="absolute right-0">
+            <AvatarMenu>
+              <Avatar />
+            </AvatarMenu>
+          </div>
+        ) : null}
       </div>
     </header>
   );

--- a/src/components/ui/Menu/AvatarMenu.tsx
+++ b/src/components/ui/Menu/AvatarMenu.tsx
@@ -1,0 +1,55 @@
+import { Popover, Transition } from "@headlessui/react";
+import Link from "next/link";
+import type { ReactNode, VFC } from "react";
+import { Fragment } from "react";
+
+import { CogIcon, LogoutIcon } from "~/components/ui/Assets/HeroIcon";
+
+type Props = {
+  children: ReactNode;
+};
+
+export const AvatarMenu: VFC<Props> = (props) => {
+  const handleLogout = () => {
+    alert("ログアウトしました");
+  };
+
+  return (
+    <Popover className="relative">
+      {({ open: _ }) => (
+        <>
+          <Popover.Button className="rounded-full outline-primary">{props.children}</Popover.Button>
+
+          <Transition
+            as={Fragment}
+            enter="transition ease-out duration-200"
+            enterFrom="opacity-0 translate-y-1"
+            enterTo="opacity-100 translate-y-0"
+            leave="transition ease-in duration-150"
+            leaveFrom="opacity-100 translate-y-0"
+            leaveTo="opacity-0 translate-y-1"
+          >
+            <Popover.Panel className="absolute right-0 z-10 py-2 mt-2 w-60 max-w-xs rounded-xl border shadow md:w-80 md:translate-x-14 lg:translate-x-1/3 bg-base-100 outline-primary border-base-200 shadow-base-200">
+              <div className="flex flex-col rounded-md">
+                <Link href="/setting">
+                  <a className="inline-flex gap-3 items-center p-2 text-sm font-bold  transition duration-150 ease-in-out md:text-base hover:bg-base-200 outline-primary">
+                    <CogIcon className="md:w-7 md:h-7 text-base-content" />
+                    設定
+                  </a>
+                </Link>
+
+                <button
+                  className="inline-flex gap-2 items-center p-2 text-sm font-bold  transition duration-150 ease-in-out md:text-base hover:bg-base-200 text-error outline-primary"
+                  onClick={handleLogout}
+                >
+                  <LogoutIcon className="ml-1 md:w-7 md:h-7 text-error" />
+                  ログアウト
+                </button>
+              </div>
+            </Popover.Panel>
+          </Transition>
+        </>
+      )}
+    </Popover>
+  );
+};

--- a/src/components/ui/Menu/AvatarMenu.tsx
+++ b/src/components/ui/Menu/AvatarMenu.tsx
@@ -1,15 +1,12 @@
 import { Popover, Transition } from "@headlessui/react";
 import Link from "next/link";
-import type { ReactNode, VFC } from "react";
+import type { VFC } from "react";
 import { Fragment } from "react";
 
+import { Avatar } from "~/components/model/user/Avatar";
 import { CogIcon, LogoutIcon } from "~/components/ui/Assets/HeroIcon";
 
-type Props = {
-  children: ReactNode;
-};
-
-export const AvatarMenu: VFC<Props> = (props) => {
+export const AvatarMenu: VFC = () => {
   const handleLogout = () => {
     alert("ログアウトしました");
   };
@@ -18,7 +15,9 @@ export const AvatarMenu: VFC<Props> = (props) => {
     <Popover className="relative">
       {({ open: _ }) => (
         <>
-          <Popover.Button className="rounded-full outline-primary">{props.children}</Popover.Button>
+          <Popover.Button className="rounded-full outline-primary">
+            <Avatar />
+          </Popover.Button>
 
           <Transition
             as={Fragment}

--- a/yarn.lock
+++ b/yarn.lock
@@ -366,6 +366,11 @@
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
   integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
 
+"@headlessui/react@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.5.0.tgz#483b44ba2c8b8d4391e1d2c863898d7dd0cc0296"
+  integrity sha512-aaRnYxBb3MU2FNJf3Ut9RMTUqqU3as0aI1lQhgo2n9Fa67wRu14iOGqx93xB+uMNVfNwZ5B3y/Ndm7qZGuFeMQ==
+
 "@heroicons/react@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@heroicons/react/-/react-1.0.6.tgz#35dd26987228b39ef2316db3b1245c42eb19e324"


### PR DESCRIPTION
<!-- あくまでテンプレートなので参考程度で！追加したい項目あれば是非！:) -->

<!-- 関連するIssue -->
close #16 

## 作成・変更内容
- HeadlessUIのPopoverを使用しました（Menuだと中のボタン類にtab移動でフォーカスを当てれなかったため）
- HeaderのAvatarにラップ

## 備考

https://user-images.githubusercontent.com/71614432/158772483-cff2cf28-3929-42eb-ad2b-4e2a155092e9.mov
