### PR TITLE
feat:device-widthが640px以下の時にinputを画面下部に固定したい

### DIFF
--- a/src/components/model/todo/MobileTodoInput.tsx
+++ b/src/components/model/todo/MobileTodoInput.tsx
@@ -1,0 +1,44 @@
+import type { FC } from "react";
+import React, { useCallback, useState } from "react";
+
+import { PlusIcon } from "~/components/ui/Assets/HeroIcon";
+
+export const MobileTodoInput: FC = () => {
+  const [todoValue, setTodoValue] = useState("");
+  const [isFocused, setIsFocused] = useState(false);
+
+  const handleChangeTodo = useCallback((e) => setTodoValue(e.target.value), []);
+  const handleFocus = useCallback(() => setIsFocused(true), []);
+  const handleBlur = useCallback(() => setIsFocused(false), []);
+
+  return (
+    <div className="block fixed bottom-0 z-50 p-2 w-full md:hidden bg-base-200">
+      <input
+        className="w-full rounded-2xl input input-primary input-sm"
+        type="text"
+        value={todoValue}
+        onChange={handleChangeTodo}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        placeholder="タスクを入力する"
+      />
+
+      {isFocused || todoValue ? (
+        <div className="flex gap-2 justify-between items-center mt-2">
+          <button className="flex flex-1 gap-0.5 items-center btn btn-primary btn-sm">
+            <PlusIcon className="w-[12px] h-[12px] text-white" />
+            今日する
+          </button>
+          <button className="flex flex-1 gap-0.5 items-center btn btn-secondary btn-sm">
+            <PlusIcon className="w-[12px] h-[12px] text-white" />
+            明日する
+          </button>
+          <button className="flex flex-1 gap-0.5 items-center btn btn-accent btn-sm">
+            <PlusIcon className="w-[12px] h-[12px] text-white" />
+            今度する
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/src/components/model/todo/MobileTodoInput.tsx
+++ b/src/components/model/todo/MobileTodoInput.tsx
@@ -12,7 +12,7 @@ export const MobileTodoInput: FC = () => {
   const handleBlur = useCallback(() => setIsFocused(false), []);
 
   return (
-    <div className="block fixed bottom-0 z-50 p-2 w-full md:hidden bg-base-200">
+    <div className="block fixed bottom-0 z-50 p-2 w-full shadow md:hidden bg-base-100">
       <input
         className="w-full rounded-2xl input input-primary input-sm"
         type="text"

--- a/src/components/model/todo/index.ts
+++ b/src/components/model/todo/index.ts
@@ -1,4 +1,5 @@
 export { AddTodoButton } from "./AddTodoButton";
+export { MobileTodoInput } from "./MobileTodoInput";
 export { TodoInput } from "./TodoInput";
 export { TodoList } from "./TodoList";
 export { TodoListItem } from "./TodoListItem";

--- a/src/components/ui/Layout/Layout.tsx
+++ b/src/components/ui/Layout/Layout.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode, VFC } from "react";
 
+import { MobileTodoInput } from "~/components/model/todo";
+
 import type { HeaderProps } from "./Header";
 import { Header } from "./Header";
 
@@ -13,17 +15,24 @@ const checkWebBrowser = () => {
   return !window.navigator.userAgent.match(/iPhone|Android.+Mobile/);
 };
 
+// const checkSmartPhoneDeviceWidth = () => {
+//   if (typeof window === "undefined") return false;
+//   return window.matchMedia("(max-device-width: 640px)").matches;
+// };
+
 export const Layout: VFC<LayoutProps> = (props) => {
   const { children, layout, ...otherProps } = props;
   const isWebBrowser = checkWebBrowser();
+  // const isSmartPhone = checkSmartPhoneDeviceWidth();
 
   const layoutStyle =
     layout === "main" ? "px-6 md:px-10 xl:px-24" : "pt-4 mx-auto max-w-screen-sm h-screen md:max-w-screen-sm";
 
   return (
-    <div>
+    <div className="relative">
       {isWebBrowser && <Header {...otherProps} />}
       <main className={layoutStyle}>{children}</main>
+      <MobileTodoInput />
     </div>
   );
 };

--- a/src/components/ui/Layout/Layout.tsx
+++ b/src/components/ui/Layout/Layout.tsx
@@ -15,7 +15,7 @@ const checkWebBrowser = () => {
   return !window.navigator.userAgent.match(/iPhone|Android.+Mobile/);
 };
 
-// const checkSmartPhoneDeviceWidth = () => {
+// const checkMobileDeviceWidth = () => {
 //   if (typeof window === "undefined") return false;
 //   return window.matchMedia("(max-device-width: 640px)").matches;
 // };
@@ -23,7 +23,7 @@ const checkWebBrowser = () => {
 export const Layout: VFC<LayoutProps> = (props) => {
   const { children, layout, ...otherProps } = props;
   const isWebBrowser = checkWebBrowser();
-  // const isSmartPhone = checkSmartPhoneDeviceWidth();
+  // const isMobileWebBrowser = checkMobileDeviceWidth();
 
   const layoutStyle =
     layout === "main" ? "px-6 md:px-10 xl:px-24" : "pt-4 mx-auto max-w-screen-sm h-screen md:max-w-screen-sm";

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -24,7 +24,11 @@ ul {
 }
 
 .btn-sm {
-  @apply h-10;
+  @apply text-xs h-9;
+}
+
+.input-sm {
+  @apply text-xs h-9;
 }
 
 .radio {


### PR DESCRIPTION
<!-- あくまでテンプレートなので参考程度で！追加したい項目あれば是非！:) -->

<!-- 関連するIssue -->
close #81 

## 作成・変更内容
native-mobileと同じコード書きました

## 相談事
1. 640px以下の場合、todo一覧を画面上で編集できないようにするか
2. そもそもWEBから見た時は、inputを画面下部に固定せずにtodo一覧上で直接編集するようにするか

## 備考

```
仮装キーボード出せるのが、Nexus5という端末だけなのでこの表示です
```

https://user-images.githubusercontent.com/71614432/162853440-959d922b-7ed4-47c2-8045-35f93a8ff8a7.mov


