### PR TITLE
feat: ローディングスピナーの作成、ユーザーアイコンのサイズ修正（UI）

### DIFF
--- a/src/components/functional/WithAuth.tsx
+++ b/src/components/functional/WithAuth.tsx
@@ -2,6 +2,8 @@ import type { WithAuthenticationRequiredOptions } from "@auth0/auth0-react";
 import { withAuthenticationRequired } from "@auth0/auth0-react";
 import type { NextPage } from "next";
 
+import { Spinner } from "~/components/ui/Layout/Spinner";
+
 /**
  * 認証済みユーザーのみが見られるページを設定するHOC
  *
@@ -15,8 +17,7 @@ export const WithAuth = (Component: NextPage<any>, options?: WithAuthenticationR
       : {
           // TODO: `returnTo`の値も検討の余地あり
           returnTo: process.env.NEXT_PUBLIC_AUTH0_REDIRECT_URI,
-          // TODO: Spinnerコンポーネントができたらここに配置する
-          onRedirecting: () => <div>Redirecting ...</div>,
+          onRedirecting: () => <Spinner />,
         },
   );
 };

--- a/src/components/ui/Assets/HeroIcon.tsx
+++ b/src/components/ui/Assets/HeroIcon.tsx
@@ -46,7 +46,7 @@ export const PlusIcon: VFC<Props> = ({ className, ...otherProps }) => {
 };
 
 export const UserCircleIcon: VFC<Props> = ({ className, ...otherProps }) => {
-  return <UserCircle className={clsx([defaultStyle, className])} {...otherProps} />;
+  return <UserCircle className={className} {...otherProps} />;
 };
 
 export const CloseIcon: VFC<Props> = ({ className, ...otherProps }) => {

--- a/src/components/ui/Layout/Spinner.tsx
+++ b/src/components/ui/Layout/Spinner.tsx
@@ -1,0 +1,9 @@
+import type { VFC } from "react";
+
+export const Spinner: VFC = () => {
+  return (
+    <div className="flex justify-center items-center h-[50vh]">
+      <div className="w-10 h-10 rounded-full border-4 border-t-transparent animate-spin border-primary"></div>
+    </div>
+  );
+};


### PR DESCRIPTION
<!-- あくまでテンプレートなので参考程度で！追加したい項目あれば是非！:) -->

<!-- 関連するIssue -->
close #79 

## 作成・変更内容
- スピナーのコンポーネントを作成し、ローディング時に表示されるようにした
- ユーザーアイコンのサイズを24pxから36pxに修正した

https://user-images.githubusercontent.com/67250685/163175946-2cf18cae-9f70-4f70-92c5-8c2a2f0a0188.mov


